### PR TITLE
Innocuous change.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - if: matrix.os == 'windows-latest'
       name: Install dependencies - Windows
-      run: pip install 'torch>=1,<2' -f https://download.pytorch.org/whl/torch_stable.html
+      run: pip install 'torch>=1,<1.8' -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install package
       run: pip install invoke .[dev]
     - name: invoke lint
@@ -58,7 +58,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - if: matrix.os == 'windows-latest'
       name: Install dependencies - Windows
-      run: pip install 'torch>=1,<2' -f https://download.pytorch.org/whl/torch_stable.html
+      run: pip install 'torch>=1,<1.8' -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install package and dependencies
       run: pip install invoke .[test]
     - name: invoke pytest
@@ -105,7 +105,7 @@ jobs:
     - if: matrix.os == 'windows-latest'
       name: Install dependencies - Windows
       run: |
-        pip install 'torch>=1,<2' -f https://download.pytorch.org/whl/torch_stable.html
+        pip install 'torch>=1,<1.8' -f https://download.pytorch.org/whl/torch_stable.html
         choco install graphviz
     - name: Install package and dependencies
       run: pip install invoke jupyter .

--- a/deepecho/models/par.py
+++ b/deepecho/models/par.py
@@ -21,7 +21,6 @@ class PARNet(torch.nn.Module):
         self.down = torch.nn.Linear(data_size + context_size, hidden_size)
         self.rnn = torch.nn.GRU(hidden_size, hidden_size)
         self.up = torch.nn.Linear(hidden_size, data_size)
-        print(".")
 
     def forward(self, x, c):
         """Forward passing computation."""

--- a/deepecho/models/par.py
+++ b/deepecho/models/par.py
@@ -21,6 +21,7 @@ class PARNet(torch.nn.Module):
         self.down = torch.nn.Linear(data_size + context_size, hidden_size)
         self.rnn = torch.nn.GRU(hidden_size, hidden_size)
         self.up = torch.nn.Linear(hidden_size, data_size)
+        print(".")
 
     def forward(self, x, c):
         """Forward passing computation."""

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ development_requires = [
     'flake8-docstrings>=1.5.0,<2',
     'flake8-sfs>=0.0.3,<0.1',
     'isort>=4.3.4,<5',
-    'pylint>=2.5.3,<2.8',
+    'pylint>=2.5.3,<2.7.2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 install_requires = [
     'numpy>=1.18.0,<2',
     'pandas>=1.1,<1.1.5',
-    'torch>=1.4,<2',
+    'torch>=1.4,<1.8',
     'tqdm>=4.10,<5',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ development_requires = [
     'flake8-docstrings>=1.5.0,<2',
     'flake8-sfs>=0.0.3,<0.1',
     'isort>=4.3.4,<5',
-    'pylint>=2.5.3,<3',
+    'pylint>=2.5.3,<2.8',
 
     # fix style issues
     'autoflake>=1.1,<2',


### PR DESCRIPTION
1) Newer versions of `pylint` (>= 2.8) fail, so I'm capping it.