### PR TITLE
Update version format for conda

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deepecho" %}
-{% set version = "version = '0.2.2.dev0'" %}
+{% set version = '0.2.2.dev0' %}
 
 package:
   name: "{{ name|lower }}"


### PR DESCRIPTION
Fix the formatting for specifying conda version.

The `conda build` command was returning the following error:
```
Error: bad character '=' in package/version: version = '0.2.1'
```