### PR TITLE
Adapt `flake8-docstrings`

### DIFF
--- a/deepecho/models/basic_gan.py
+++ b/deepecho/models/basic_gan.py
@@ -171,6 +171,7 @@ class BasicGANModel(DeepEcho):
         LOGGER.info('%s instance created', self)
 
     def __repr__(self):
+        """Return a representation of the class object."""
         return (
             f'{self.__class__.__name__}(epochs={self._epochs}, latent_size={self._latent_size},'
             f'hidden_size={self._hidden_size}, gen_lr={self._gen_lr}, dis_lr={self._dis_lr},'

--- a/deepecho/models/par.py
+++ b/deepecho/models/par.py
@@ -275,6 +275,8 @@ class PARModel(DeepEcho):
     def fit_sequences(self, sequences, context_types, data_types):
         """Fit a model to the specified sequences.
 
+        This is a method description.
+
         Args:
             sequences (list):
                 List of sequences. Each sequence is a single training example
@@ -524,6 +526,8 @@ class PARModel(DeepEcho):
 
     def sample_sequence(self, context, sequence_length=None):
         """Sample a single sequence conditioned on context.
+
+        This is a method description.
 
         Args:
             context (list):

--- a/deepecho/models/par.py
+++ b/deepecho/models/par.py
@@ -109,6 +109,7 @@ class PARModel(DeepEcho):
         LOGGER.info('%s instance created', self)
 
     def __repr__(self):
+        """Return a representation of the class object."""
         return (
             f'{self.__class__.__name__}(epochs={self.epochs}, sample_size={self.sample_size},'
             f"cuda='{self.device}', verbose={self.verbose})"

--- a/deepecho/models/par.py
+++ b/deepecho/models/par.py
@@ -275,8 +275,6 @@ class PARModel(DeepEcho):
     def fit_sequences(self, sequences, context_types, data_types):
         """Fit a model to the specified sequences.
 
-        This is a method description.
-
         Args:
             sequences (list):
                 List of sequences. Each sequence is a single training example
@@ -526,8 +524,6 @@ class PARModel(DeepEcho):
 
     def sample_sequence(self, context, sequence_length=None):
         """Sample a single sequence conditioned on context.
-
-        This is a method description.
 
         Args:
             context (list):

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,8 @@ test = pytest
 collect_ignore = ['setup.py']
 
 [pydocstyle]
-ignore = D105, D107, D407, D203, D213, D413, D406, D417
+convention = google
+add-ignore = D107, D407, D417, D105
 
 [pylint]
 persistent = no

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ universal = 1
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 extend-ignore =
-    D105, # Missing docstring in magic method
     D107, # Missing docstring in __init__
+    D407, # Missing dashed underline after section
     SFS3, # String formating using f-string
     VNE001, # Single letter variable names are not allowed.
 
@@ -63,7 +63,7 @@ collect_ignore = ['setup.py']
 
 [pydocstyle]
 convention = google
-add-ignore = D107, D407, D417, D105
+add-ignore = D107, D407, D417
 
 [pylint]
 persistent = no

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,12 @@ universal = 1
 [flake8]
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
+docstring-convetion = google
 extend-ignore =
     SFS3, # String formating using f-string
     VNE001, # Single letter variable names are not allowed.
+    D107,  # Missing docstring in __init__
+    D417   # Missing argument descriptions in the docstring, this is a bug from pydocstyle: https://github.com/PyCQA/pydocstyle/issues/449
 
 ignore-names =
     X,
@@ -58,13 +61,6 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-
-[pydocstyle]
-convention = google
-add-ignore =
-    D107,  # Missing docstring in __init__
-    D407,  # Missing dashed underline after section
-    D417   # Ignored because of a bug with google-style convention
 
 [pylint]
 persistent = no

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,6 @@ universal = 1
 max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 extend-ignore =
-    D107, # Missing docstring in __init__
-    D407, # Missing dashed underline after section
     SFS3, # String formating using f-string
     VNE001, # Single letter variable names are not allowed.
 
@@ -63,7 +61,10 @@ collect_ignore = ['setup.py']
 
 [pydocstyle]
 convention = google
-add-ignore = D107, D407, D417
+add-ignore =
+    D107,  # Missing docstring in __init__
+    D407,  # Missing dashed underline after section
+    D417   # Ignored because of a bug with google-style convention
 
 [pylint]
 persistent = no

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ development_requires = [
     'pep8-naming>=0.12.1,<0.13',
     'flake8-expression-complexity>=0.0.9,<0.1',
     'flake8-print>=4.0.0,<4.1',
+    'pydocstyle>=6.1.1,<6.2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ development_requires = [
     'pep8-naming>=0.12.1,<0.13',
     'flake8-expression-complexity>=0.0.9,<0.1',
     'flake8-print>=4.0.0,<4.1',
-    'pydocstyle>=6.1.1,<6.2',
 
     # fix style issues
     'autoflake>=1.1,<2',

--- a/tasks.py
+++ b/tasks.py
@@ -114,11 +114,10 @@ def tutorials(c):
 @task
 def lint(c):
     check_dependencies(c)
-    c.run('flake8 deepecho --ignore=D')
-    c.run('flake8 tests --ignore=D')
+    c.run('flake8 deepecho')
+    c.run('flake8 tests')
     c.run('isort -c --recursive deepecho tests')
     c.run('pylint deepecho --rcfile=setup.cfg')
-    c.run('pydocstyle deepecho tests')
 
 
 def remove_readonly(func, path, _):

--- a/tasks.py
+++ b/tasks.py
@@ -115,7 +115,7 @@ def tutorials(c):
 def lint(c):
     check_dependencies(c)
     c.run('flake8 deepecho')
-    c.run('flake8 tests --ignore=D,SFS2')
+    c.run('flake8 tests --ignore=D')
     c.run('isort -c --recursive deepecho tests')
     c.run('pylint deepecho --rcfile=setup.cfg')
     c.run('pydocstyle deepecho tests')

--- a/tasks.py
+++ b/tasks.py
@@ -118,7 +118,7 @@ def lint(c):
     c.run('flake8 tests --ignore=D,SFS2')
     c.run('isort -c --recursive deepecho tests')
     c.run('pylint deepecho --rcfile=setup.cfg')
-    c.run('pydocstyle deepecho')
+    c.run('pydocstyle deepecho tests')
 
 
 def remove_readonly(func, path, _):

--- a/tasks.py
+++ b/tasks.py
@@ -118,6 +118,7 @@ def lint(c):
     c.run('flake8 tests --ignore=D,SFS2')
     c.run('isort -c --recursive deepecho tests')
     c.run('pylint deepecho --rcfile=setup.cfg')
+    c.run('pydocstyle deepecho')
 
 
 def remove_readonly(func, path, _):

--- a/tasks.py
+++ b/tasks.py
@@ -114,7 +114,7 @@ def tutorials(c):
 @task
 def lint(c):
     check_dependencies(c)
-    c.run('flake8 deepecho')
+    c.run('flake8 deepecho --ignore=D')
     c.run('flake8 tests --ignore=D')
     c.run('isort -c --recursive deepecho tests')
     c.run('pylint deepecho --rcfile=setup.cfg')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""DeepEcho test module."""

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""DeepEcho integration testing package."""

--- a/tests/integration/test_basic_gan.py
+++ b/tests/integration/test_basic_gan.py
@@ -1,11 +1,15 @@
+"""Integration tests for ``BasicGANModel``."""
+
 import unittest
 
 from deepecho.models.basic_gan import BasicGANModel
 
 
 class TestBasicGANModel(unittest.TestCase):
+    """Test class for the ``BasicGANModel``."""
 
     def test_basic(self):
+        """Basic test for the ``BasicGANModel``."""
         sequences = [
             {
                 'context': [],
@@ -30,6 +34,7 @@ class TestBasicGANModel(unittest.TestCase):
         model.sample_sequence([])
 
     def test_conditional(self):
+        """Test the ``BasicGANModel`` with conditional sampling."""
         sequences = [
             {
                 'context': [0],
@@ -54,6 +59,7 @@ class TestBasicGANModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_mixed(self):
+        """Test the ``BasicGANModel`` with mixed input data."""
         sequences = [
             {
                 'context': [0],
@@ -78,6 +84,7 @@ class TestBasicGANModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_count(self):
+        """Test the BasicGANModel with datatype ``count``."""
         sequences = [
             {
                 'context': [0.5],
@@ -102,6 +109,7 @@ class TestBasicGANModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_variable_length(self):
+        """Test ``BasicGANModel`` with variable data length."""
         sequences = [
             {
                 'context': [0],

--- a/tests/integration/test_par.py
+++ b/tests/integration/test_par.py
@@ -1,3 +1,5 @@
+"""Integration tests for ``PARModel``."""
+
 import unittest
 
 import numpy as np
@@ -6,8 +8,10 @@ from deepecho.models.par import PARModel
 
 
 class TestPARModel(unittest.TestCase):
+    """Test class for the ``PARModel``."""
 
     def test_basic(self):
+        """Test the basic usage of a ``PARModel``."""
         sequences = [
             {
                 'context': [],
@@ -32,6 +36,7 @@ class TestPARModel(unittest.TestCase):
         model.sample_sequence([])
 
     def test_conditional(self):
+        """Test the ``PARModel`` with conditional sampling."""
         sequences = [
             {
                 'context': [0],
@@ -56,6 +61,7 @@ class TestPARModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_mixed(self):
+        """Test the ``PARModel`` with mixed input data."""
         sequences = [
             {
                 'context': [0],
@@ -80,6 +86,7 @@ class TestPARModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_count(self):
+        """Test the PARModel with datatype ``count``."""
         sequences = [
             {
                 'context': [0.5],
@@ -104,6 +111,7 @@ class TestPARModel(unittest.TestCase):
         model.sample_sequence([0])
 
     def test_variable_length(self):
+        """Test ``PARModel`` with variable data length."""
         sequences = [
             {
                 'context': [0],

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""DeepEcho unit testing package."""

--- a/tests/unit/test_sequences.py
+++ b/tests/unit/test_sequences.py
@@ -1,3 +1,5 @@
+"""Unit tests for sequences module."""
+
 import pandas as pd
 import pytest
 


### PR DESCRIPTION
As part of #38 

This `pr` fixes the `flake8-docstrings` to use the `google-docstring` convention and enable it for all of the repository.