### PR TITLE
Handle PARSynthesizer model if sequence_index is missing

### DIFF
--- a/deepecho/sequences.py
+++ b/deepecho/sequences.py
@@ -107,7 +107,8 @@ def segment_sequence(sequence, segment_size, sequence_index, drop_sequence_index
 def _convert_to_dicts(segments, context_columns):
     sequences = []
     for segment in segments:
-        if context_columns:
+        missing_columns = [col for col in context_columns if col not in segment.columns]
+        if context_columns and not missing_columns:
             context = segment[context_columns]
             if len(context.drop_duplicates()) > 1:
                 raise ValueError('Context columns are not constant within each segment.')
@@ -181,7 +182,8 @@ def assemble_sequences(
         groupby_columns = entity_columns[0] if len(entity_columns) == 1 else entity_columns
         for _, sequence in data.groupby(groupby_columns):
             sequence.drop(entity_columns, axis=1, inplace=True)
-            if context_columns:
+            missing_columns = [col for col in context_columns if col not in sequence.columns]
+            if context_columns and not missing_columns:
                 if len(sequence[context_columns].drop_duplicates()) > 1:
                     raise ValueError('Context columns are not constant within each entity.')
 

--- a/tests/unit/test_sequences.py
+++ b/tests/unit/test_sequences.py
@@ -293,3 +293,35 @@ def test__assemble_sequences_entity_and_time_segment_size():
             ],
         },
     ]
+
+
+def test__assemble_sequences_missing_context_in_data():
+    """Test if context column is not found in data"""
+    entity_columns = ['a']
+    context_columns = ['f']
+
+    data = pd.DataFrame({
+        'a': [1, 1, 1, 1],
+        'b': [1, 2, 3, 4],
+        'c': [9, 8, 7, 6],
+        'time': pd.date_range(start='2001-01-01', periods=4, freq='1d'),
+    })
+    out = assemble_sequences(data, entity_columns, context_columns, pd.to_timedelta('2d'), 'time')
+
+    assert isinstance(out, list)
+    assert out == [
+        {
+            'context': [],
+            'data': [
+                [1, 2],
+                [9, 8],
+            ],
+        },
+        {
+            'context': [],
+            'data': [
+                [3, 4],
+                [7, 6],
+            ],
+        },
+    ]


### PR DESCRIPTION
resolves https://github.com/sdv-dev/SDV/issues/1972
CU-86b08wr44


When sequence index is missing, par.py adds a constant column to allow for modeling as seen [here](https://github.com/sdv-dev/SDV/blob/main/sdv/sequential/par.py#L250). The added context column does not exist in the data though causing `KeyErrors`. Added a check to prevent failures.
